### PR TITLE
Add additional table prototype for json string array

### DIFF
--- a/config/packages/doctrine.php
+++ b/config/packages/doctrine.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+return static function (ContainerConfigurator $container) {
+    $proxyDirectory = dirname(__DIR__, 2) . '/var/cache/' . $_SERVER['APP_ENV'] . '/orm-proxies';
+
+    $container->parameters()
+        ->set('orm_array_proxy.proxy_directory', $proxyDirectory);
+
+    $filesystem = new Filesystem();
+    if (!$filesystem->exists($proxyDirectory)) {
+        $filesystem->mkdir($proxyDirectory);
+    }
+
+    $container->extension('doctrine', [
+        'orm' => [
+            'mappings' => [
+                'ORMArrayProxy' => [
+                    'is_bundle' => false,
+                    'type' => 'staticphp',
+                    'dir' => $proxyDirectory,
+                    'prefix' => 'ORMArrayProxy',
+                    'alias' => 'ORMArrayProxy',
+                ]
+            ],
+        ],
+    ]);
+};

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -16,3 +16,4 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Entity'
                 prefix: 'App\Entity'
                 alias: App
+        class_metadata_factory_name: App\Infrastructure\Doctrine\ClassMetadataFactory

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -10,6 +10,9 @@ services:
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+        bind:
+            $proxyDirectory: '%orm_array_proxy.proxy_directory%'
+            $staticPHPDriver: '@doctrine.orm.default_staticphp_metadata_driver'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\PageRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Event
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @var iterable<\Stringable|string>
+     *
+     * @ORM\Column(type="json", options={"string-array": true})
+     */
+    private $locales;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    public function getLocales(): iterable
+    {
+        $locales = [];
+        foreach ($this->locales as $locale) {
+            $locales = (string) $locale;
+        }
+
+        return $locales;
+    }
+}

--- a/src/Entity/Page.php
+++ b/src/Entity/Page.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\PageRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass=PageRepository::class)
+ */
+class Page
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @var iterable<\Stringable|string>
+     *
+     * @ORM\Column(type="json", options={"string-array": true})
+     */
+    private $locales;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    public function getLocales(): iterable
+    {
+        $locales = [];
+        foreach ($this->locales as $locale) {
+            $locales = (string) $locale;
+        }
+
+        return $locales;
+    }
+}

--- a/src/Infrastructure/Doctrine/ClassMetadataFactory.php
+++ b/src/Infrastructure/Doctrine/ClassMetadataFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Infrastructure\Doctrine;
+
+use Doctrine\Bundle\DoctrineBundle\Mapping\ClassMetadataFactory as DoctrineClassMetadataFactory;
+
+class ClassMetadataFactory extends DoctrineClassMetadataFactory
+{
+    private static $initializedAllMetadata = false;
+
+    public function getAllMetadata(): array
+    {
+        if (!static::$initializedAllMetadata) {
+            // TODO avoid duplicated call of getAllMetadata
+            parent::getAllMetadata();
+
+            static::$initializedAllMetadata = true;
+        }
+
+        return parent::getAllMetadata();
+    }
+}

--- a/src/Infrastructure/Doctrine/MetadataLoader.php
+++ b/src/Infrastructure/Doctrine/MetadataLoader.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Doctrine;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver;
+
+class MetadataLoader implements EventSubscriber
+{
+    /**
+     * @var string
+     */
+    private $proxyDirectory;
+
+    /**
+     * @var StaticPHPDriver
+     */
+    private $staticPHPDriver;
+
+    public function __construct(
+        string $proxyDirectory,
+        StaticPHPDriver $staticPHPDriver
+    ) {
+        $this->proxyDirectory = $proxyDirectory;
+        $this->staticPHPDriver = $staticPHPDriver;
+    }
+
+    public function getSubscribedEvents()
+    {
+        return [
+            Events::loadClassMetadata,
+        ];
+    }
+
+    public function loadClassMetadata(LoadClassMetadataEventArgs $event): void
+    {
+        /** @var ClassMetadataInfo<object> $metadata */
+        $metadata = $event->getClassMetadata();
+        $reflection = $metadata->getReflectionClass();
+        $className = $reflection->getName();
+
+        foreach ($metadata->getFieldNames() as $fieldName) {
+            $typeOfField = $metadata->getTypeOfField($fieldName);
+            $mapping = $metadata->getFieldMapping($fieldName);
+
+            if ($typeOfField !== 'json') {
+                continue;
+            }
+
+            if (! ($mapping['options']['string-array'] ?? false)) {
+                continue;
+            }
+
+            // remove exist metadata for field via reflection
+            $metadataReflection = new \ReflectionClass($metadata);
+
+            $propertyFieldMappingsReflection = $metadataReflection->getProperty('fieldMappings');
+            $propertyFieldMappingsReflection->setAccessible(true);
+            $fieldMappings = $propertyFieldMappingsReflection->getValue($metadata);
+            unset($fieldMappings[$fieldName]);
+            $propertyFieldMappingsReflection->setValue($metadata, $fieldMappings);
+
+            $propertyFieldNamesReflection = $metadataReflection->getProperty('fieldNames');
+            $propertyFieldNamesReflection->setAccessible(true);
+            $fieldNames = $propertyFieldNamesReflection->getValue($metadata);
+            unset($fieldNames[\array_search($fieldName, $fieldNames)]);
+            $propertyFieldNamesReflection->setValue($metadata, $fieldNames);
+
+            $propertyColumnNamesReflection = $metadataReflection->getProperty('columnNames');
+            $propertyColumnNamesReflection->setAccessible(true);
+            $columnNames = $propertyColumnNamesReflection->getValue($metadata);
+            unset($columnNames[$fieldName]);
+            $propertyFieldNamesReflection->setValue($metadata, $columnNames);
+
+            // create proxy relation entity
+            $fqcnClassName = 'ORMArrayProxy\\' . 'Proxy_' . sha1($className . '_' . $fieldName);
+
+            try {
+                $reflectionClass = new \ReflectionClass($fqcnClassName);
+                $fileExists = file_exists($reflectionClass->getFileName());
+            } catch (\ReflectionException $e) {
+                $fileExists = false;
+            }
+
+            if (!$fileExists) {
+                $this->dumpProxyClass(
+                    $fqcnClassName,
+                    $className,
+                    $fieldName,
+                    $metadata->getTableName() . '_' . $fieldName,
+                    $metadata->getIdentifier()[0]
+                );
+            }
+
+            // refresh metadata cache with new proxy entity
+            $metadataFactory = $event->getEntityManager()->getMetadataFactory();
+            if (!$metadataFactory->hasMetadataFor($fqcnClassName)) {
+                // TODO metadata is correctly loaded here but not persisted
+                //      e.g.:
+                //          rm -rf var/cache
+                //          bin/console doctrine:schema:update --dump-sql
+                //          # metadata is not shown
+                //          bin/console doctrine:schema:update --dump-sql
+                //          # metadata is now shown
+
+                // $metadata = $metadataFactory->getMetadataFor($fqcnClassName);
+
+                $configuration = $event->getEntityManager()->getConfiguration();
+                $metadataDriver = $configuration->getMetadataDriverImpl();
+                $reflectionService = $metadataFactory->getReflectionService();
+
+                $metadata = new ClassMetadata($fqcnClassName, $configuration->getNamingStrategy());
+                $metadata->initializeReflection($reflectionService);
+
+                $metadataDriver->loadMetadataForClass(
+                    $fqcnClassName,
+                    $metadata
+                );
+
+                // reset StaticPHPDriver classNames
+                $reflection = new \ReflectionClass($this->staticPHPDriver);
+                if (!$reflection->hasProperty('classNames')) {
+                    $reflection = $reflection->getParentClass();
+                }
+                $propertyClassNamesReflection = $reflection->getProperty('classNames');
+                $propertyClassNamesReflection->setAccessible(true);
+                $propertyClassNamesReflection->setValue($this->staticPHPDriver, null);
+            }
+
+            // add new relation
+            $metadata->mapOneToMany([
+                'fieldName' => $fieldName,
+                'targetEntity' => $fqcnClassName,
+                'mappedBy' => 'object',
+            ]);
+        }
+    }
+
+    private function dumpProxyClass(
+        string $fqcnClassName,
+        string $targetEntity,
+        string $inversedBy,
+        string $tableName,
+        string $referenceColumn
+    ): void {
+        $classNameParts = explode('\\', $fqcnClassName);
+        $className = $classNameParts[count($classNameParts) - 1];
+
+        $classContent = $this->getClassContent();
+
+        $classContent = (\str_replace('%CLASSNAME%', $className, $classContent));
+        $classContent = (\str_replace('%TARGET_ENTITY%', $targetEntity, $classContent));
+        $classContent = (\str_replace('%INVERSED_BY%', $inversedBy, $classContent));
+        $classContent = (\str_replace('%TABLE_NAME%', $tableName, $classContent));
+        $classContent = (\str_replace('%REFERENCE_COLUMN%', $referenceColumn, $classContent));
+        $filePath = $this->proxyDirectory . DIRECTORY_SEPARATOR . $className . '.php';
+
+        file_put_contents($filePath, $classContent);
+
+        require_once($filePath);
+    }
+
+    private function getClassContent(): string
+    {
+        return <<<EOT
+<?php
+
+namespace ORMArrayProxy;
+
+use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+/**
+ * @internal
+ */
+class %CLASSNAME% implements \Stringable
+{
+    /**
+     * @var null|string
+     */
+    public static \$targetEntity = '%TARGET_ENTITY%';
+
+    /**
+     * @var null|string
+     */
+    public static \$inversedBy = '%INVERSED_BY%';
+
+    /**
+     * @var null|string
+     */
+    public static \$tableName = '%TABLE_NAME%';
+
+    /**
+     * @var null|string
+     */
+    public static \$referenceColumn =  '%REFERENCE_COLUMN%';
+    
+    /**
+     * @var object
+     */
+    protected \$object;
+
+    /**
+     * @var string
+     */
+    protected \$string = '';
+
+    public function __toString(): string
+    {
+        return \$this->string;
+    }
+
+    public static function loadMetadata(ClassMetadata \$metadata)
+    {
+        \$builder = new ClassMetadataBuilder(\$metadata);
+
+        \$builder->setTable(static::\$tableName);
+
+        \$builder->createManyToOne(
+            'object',
+            static::\$targetEntity
+        )
+            ->inversedBy(static::\$inversedBy)
+            ->addJoinColumn(
+                'object_id',
+                static::\$referenceColumn,
+                true,
+                false,
+                'CASCADE'
+            )
+            ->makePrimaryKey()
+            ->build();
+
+        \$builder->createField('string', 'string')
+            ->columnName('string')
+            ->makePrimaryKey()
+            ->build();
+
+        \$builder->addIndex(['string'], 'idx_string');
+        \$builder->addIndex(['string', 'object_id'], 'idx_object_string');
+    }
+}
+EOT;
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -14,6 +14,7 @@ class Kernel extends BaseKernel
     protected function configureContainer(ContainerConfigurator $container): void
     {
         $container->import('../config/{packages}/*.yaml');
+        $container->import('../config/{packages}/*.php');
         $container->import('../config/{packages}/'.$this->environment.'/*.yaml');
 
         if (is_file(\dirname(__DIR__).'/config/services.yaml')) {


### PR DESCRIPTION
This pull request contains a lot of hacks, but good for a prototype. It generates a dynamic class which will generate a table instead of json array.

### TODO

 - [ ] Move generating of Proxy Classes to compilerpass
      - [ ] Alternative listen to onClassMetadataNotFound exception
      - [ ] Find out how to access mapping configuration in compilerpass
      - [ ] Remove custom ClassMetadataFactory with duplicated getAllmetadata call
 - [ ] Implement [MEMBER OF](https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#operator_member-of) query method which should join the additional table

#### Version A (move json to own to many table)

 - [ ] Convert $locales array to collection on persist / update
 - [ ] Convert $locales collection to array on load

#### Version B (duplicate data to additional table)

 - [ ] Keep json field
 - [ ] Add additional `$localeCollection` only for filter query
 - [ ] Add ore remove locales on Persist / Update events check over unit of work diff
 
The entity should register the array field the following way:

```php
    /**
     * @var iterable<\Stringable|string>
     *
     * @ORM\Column(type="json", options={"string-array": true})
     */
    private $locales;
```

The metadata loader will convert the json into a additonal table with a stringable entity.

```sql
CREATE TABLE event (id INT AUTO_INCREMENT NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB;
CREATE TABLE page (id INT AUTO_INCREMENT NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB;

CREATE TABLE page_locales (string VARCHAR(255) NOT NULL, object_id INT NOT NULL, INDEX IDX_1FFBBF2E232D562B (object_id), INDEX idx_string (string), INDEX idx_object_string (string, object_id), PRIMARY KEY(object_id, string)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB;

CREATE TABLE event_locales (string VARCHAR(255) NOT NULL, object_id INT NOT NULL, INDEX IDX_60CCFD14232D562B (object_id), INDEX idx_string (string), INDEX idx_object_string (string, object_id), PRIMARY KEY(object_id, string)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB;

ALTER TABLE page_locales ADD CONSTRAINT FK_1FFBBF2E232D562B FOREIGN KEY (object_id) REFERENCES page (id) ON DELETE CASCADE;
ALTER TABLE event_locales ADD CONSTRAINT FK_60CCFD14232D562B FOREIGN KEY (object_id) REFERENCES event (id) ON DELETE CASCADE;
``` 

A proxy class which implements \Stringable is created which looks like the following:

> The proxy class name is a sha1 hash over the related entity full qualified class name plus the related field name.

```php
<?php

namespace ORMArrayProxy;

use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
use Doctrine\ORM\Mapping\ClassMetadata;

/**
 * @internal
 */
class Proxy_0607a2d5cae4c928270cdaf51534266e1871bb19 implements \Stringable
{
    /**
     * @var null|string
     */
    public static $targetEntity = 'App\Entity\Page';

    /**
     * @var null|string
     */
    public static $inversedBy = 'locales';

    /**
     * @var null|string
     */
    public static $tableName = 'page_locales';

    /**
     * @var null|string
     */
    public static $referenceColumn =  'id';
    
    /**
     * @var object
     */
    protected $object;

    /**
     * @var string
     */
    protected $string = '';

    public function __toString(): string
    {
        return $this->string;
    }

    public static function loadMetadata(ClassMetadata $metadata)
    {
        $builder = new ClassMetadataBuilder($metadata);

        $builder->setTable(static::$tableName);

        $builder->createManyToOne(
            'object',
            static::$targetEntity
        )
            ->inversedBy(static::$inversedBy)
            ->addJoinColumn(
                'object_id',
                static::$referenceColumn,
                true,
                false,
                'CASCADE'
            )
            ->makePrimaryKey()
            ->build();

        $builder->createField('string', 'string')
            ->columnName('string')
            ->makePrimaryKey()
            ->build();

        $builder->addIndex(['string'], 'idx_string');
        $builder->addIndex(['string', 'object_id'], 'idx_object_string');
    }
}
```

